### PR TITLE
Add live research updates and log schema

### DIFF
--- a/src/main/java/pl/yourserver/scientistPlugin/db/Database.java
+++ b/src/main/java/pl/yourserver/scientistPlugin/db/Database.java
@@ -81,6 +81,18 @@ public class Database {
                             "INDEX (player_uuid), INDEX (status), INDEX (end_at))")) {
                 ps.execute();
             }
+            // sci_experiment_log
+            try (PreparedStatement ps = c.prepareStatement(
+                    "CREATE TABLE IF NOT EXISTS sci_experiment_log (" +
+                            "id BIGINT AUTO_INCREMENT PRIMARY KEY," +
+                            "player_uuid BINARY(16) NOT NULL," +
+                            "recipe_key VARCHAR(64) NOT NULL," +
+                            "started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                            "metadata TEXT," +
+                            "FOREIGN KEY (recipe_key) REFERENCES sci_recipe(recipe_key)," +
+                            "INDEX (player_uuid), INDEX (started_at))")) {
+                ps.execute();
+            }
             // sci_abyssal_log
             try (PreparedStatement ps = c.prepareStatement(
                     "CREATE TABLE IF NOT EXISTS sci_abyssal_log (" +


### PR DESCRIPTION
## Summary
- create the `sci_experiment_log` table during database initialization to resolve the missing table exception
- update the research GUI to reuse the open inventory, refresh the running experiment timer, and block the start button while an experiment is active
- mark expired experiments and adjust queries so concurrency checks and claim flows reflect finished timers immediately

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e8d79bfb08832aa8be76378264be04