### PR TITLE
Fix experiment log recipe key

### DIFF
--- a/src/main/java/pl/yourserver/scientistPlugin/research/ResearchService.java
+++ b/src/main/java/pl/yourserver/scientistPlugin/research/ResearchService.java
@@ -125,7 +125,7 @@ public class ResearchService {
             String desc = recipe.getString("description", "");
             try (PreparedStatement ps = c.prepareStatement("INSERT INTO sci_experiment_log (player_uuid, recipe_key, started_at, metadata) VALUES (UNHEX(REPLACE(?,'-','')), ?, NOW(), ?)")) {
                 ps.setString(1, player.getUniqueId().toString());
-                ps.setString(2, title);
+                ps.setString(2, recipeKey);
                 ps.setString(3, desc);
                 ps.executeUpdate();
             }


### PR DESCRIPTION
## Summary
- ensure experiment log entries store the actual recipe key to satisfy the foreign key constraint

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e8dfd35de8832ab3095e0e6e49a2f4